### PR TITLE
Rust 1.0.0-alpha fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,162 +2,187 @@
 name = "wca-api-rust"
 version = "0.0.1"
 dependencies = [
+ "http 0.1.0-pre (git+https://github.com/nickel-org/rust-http.git)",
  "nickel 0.1.0 (git+https://github.com/nickel-org/nickel.rs.git)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "wca-data 0.0.1",
 ]
 
 [[package]]
 name = "anymap"
-version = "0.9.0"
-source = "git+https://github.com/nickel-org/anymap.git#15cad51ac750ea5209d5882379a055f9b8057720"
+version = "0.9.9"
+source = "git+https://github.com/nickel-org/anymap.git#26ca567814442053601fe8692b872fe8fefc577f"
 
 [[package]]
 name = "csv"
-version = "0.7.1"
-source = "git+git://github.com/BurntSushi/rust-csv#5416ec612250ec14845d7e7b430ef8a26084df23"
-
-[[package]]
-name = "encoding"
-version = "0.2.5"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
+version = "0.12.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "encoding-index-japanese 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
- "encoding-index-korean 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
- "encoding-index-simpchinese 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
- "encoding-index-singlebyte 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
- "encoding-index-tradchinese 1.0.20140915 (git+https://github.com/lifthrasiir/rust-encoding)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "encoding-index-japanese"
-version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
-dependencies = [
- "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
-]
-
-[[package]]
-name = "encoding-index-korean"
-version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
-dependencies = [
- "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
-]
-
-[[package]]
-name = "encoding-index-simpchinese"
-version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
-dependencies = [
- "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
-]
-
-[[package]]
-name = "encoding-index-singlebyte"
-version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
-dependencies = [
- "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
-]
-
-[[package]]
-name = "encoding-index-tradchinese"
-version = "1.0.20140915"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
-dependencies = [
- "encoding_index_tests 0.1.0 (git+https://github.com/lifthrasiir/rust-encoding)",
-]
-
-[[package]]
-name = "encoding_index_tests"
-version = "0.1.0"
-source = "git+https://github.com/lifthrasiir/rust-encoding#210beb5e37649b7136d27069c1f1b36a513fa76a"
 
 [[package]]
 name = "gcc"
-version = "0.1.0"
-source = "git+https://github.com/alexcrichton/gcc-rs#6b60df5cec47c6e74d8f86a1216e202268727a72"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "groupable"
 version = "0.1.0"
-source = "git+https://github.com/nickel-org/groupable-rs#74c9e38ede02008fc04c47a33c4ba9b995dc3606"
+source = "git+https://github.com/nickel-org/groupable-rs#efc8d769f611558f086322cd8d2d5ff53314e435"
 
 [[package]]
 name = "http"
 version = "0.1.0-pre"
-source = "git+https://github.com/nickel-org/rust-http.git#2d2b9784b74ca78d6a7918a14a79bea8b7094ed8"
+source = "git+https://github.com/nickel-org/rust-http.git#1605a5163fe87c189d45913caa33f0e9e6bade48"
 dependencies = [
- "openssl 0.2.2 (git+https://github.com/sfackler/rust-openssl.git)",
- "time 0.1.0 (git+https://github.com/rust-lang/time)",
- "url 0.1.0 (git+https://github.com/nickel-org/rust-url.git)",
+ "openssl 0.2.18 (git+https://github.com/sfackler/rust-openssl.git)",
+ "time 0.1.15 (git+https://github.com/rust-lang/time)",
+ "url 0.2.17 (git+https://github.com/nickel-org/rust-url.git)",
 ]
+
+[[package]]
+name = "libc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "libressl-pnacl-sys"
+version = "2.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "pnacl-build-helper 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "nickel"
 version = "0.1.0"
-source = "git+https://github.com/nickel-org/nickel.rs.git#42fb537a1136b092e7ddd3b1b6b9e613fe21972c"
+source = "git+https://github.com/nickel-org/nickel.rs.git#f14aadb03b786aa175c38e8f8e76621da4489835"
 dependencies = [
- "anymap 0.9.0 (git+https://github.com/nickel-org/anymap.git)",
+ "anymap 0.9.9 (git+https://github.com/nickel-org/anymap.git)",
  "groupable 0.1.0 (git+https://github.com/nickel-org/groupable-rs)",
  "http 0.1.0-pre (git+https://github.com/nickel-org/rust-http.git)",
  "nickel_macros 0.0.1 (git+https://github.com/nickel-org/nickel.rs.git)",
+ "plugin 0.2.0 (git+https://github.com/reem/rust-plugin)",
+ "regex 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex_macros 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-mustache 0.3.0 (git+https://github.com/nickel-org/rust-mustache.git)",
- "time 0.1.0 (git+https://github.com/rust-lang/time)",
- "url 0.1.0 (git+https://github.com/nickel-org/rust-url.git)",
+ "time 0.1.15 (git+https://github.com/rust-lang/time)",
+ "typemap 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 0.2.17 (git+https://github.com/nickel-org/rust-url.git)",
 ]
 
 [[package]]
 name = "nickel_macros"
 version = "0.0.1"
-source = "git+https://github.com/nickel-org/nickel.rs.git#42fb537a1136b092e7ddd3b1b6b9e613fe21972c"
+source = "git+https://github.com/nickel-org/nickel.rs.git#f14aadb03b786aa175c38e8f8e76621da4489835"
 
 [[package]]
 name = "openssl"
-version = "0.2.2"
-source = "git+https://github.com/sfackler/rust-openssl.git#b8a41f79a1a78791dddd453db0aab5f0957152fc"
+version = "0.2.18"
+source = "git+https://github.com/sfackler/rust-openssl.git#8b47daae66db425574fe85a687a7a09966feb1b3"
 dependencies = [
- "openssl-sys 0.2.2 (git+https://github.com/sfackler/rust-openssl.git)",
+ "openssl-sys 0.2.18 (git+https://github.com/sfackler/rust-openssl.git)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.2.2"
-source = "git+https://github.com/sfackler/rust-openssl.git#b8a41f79a1a78791dddd453db0aab5f0957152fc"
+version = "0.2.18"
+source = "git+https://github.com/sfackler/rust-openssl.git#8b47daae66db425574fe85a687a7a09966feb1b3"
 dependencies = [
- "pkg-config 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libressl-pnacl-sys 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "pkg-config"
-version = "0.1.0"
+name = "phantom"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "pkg-config"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "plugin"
+version = "0.2.0"
+source = "git+https://github.com/reem/rust-plugin#fea209785ef6d9662374897287dfe509af934141"
+dependencies = [
+ "phantom 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "typemap 0.0.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pnacl-build-helper"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "regex_macros"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "regex 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rust-mustache"
 version = "0.3.0"
-source = "git+https://github.com/nickel-org/rust-mustache.git#6f98a76ba46068f04c14b942a182e29eea24350e"
+source = "git+https://github.com/nickel-org/rust-mustache.git#274b1b9b8159cae4f993a1b9383f911ca0128827"
+
+[[package]]
+name = "rustc-serialize"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "time"
-version = "0.1.0"
-source = "git+https://github.com/rust-lang/time#b8e219aa9fca15ed1377a7d62aff1eb4378f3ba4"
+version = "0.1.15"
+source = "git+https://github.com/rust-lang/time#e216d0de7377a1ae5c8617f6e1a9f60dc61d7ec7"
 dependencies = [
- "gcc 0.1.0 (git+https://github.com/alexcrichton/gcc-rs)",
+ "gcc 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "url"
-version = "0.1.0"
-source = "git+https://github.com/nickel-org/rust-url.git#5d15bee2d296b0fc3cfae84e69d1d2e865cf9335"
+name = "typemap"
+version = "0.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "encoding 0.2.5 (git+https://github.com/lifthrasiir/rust-encoding)",
+ "phantom 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unsafe-any 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unsafe-any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "url"
+version = "0.2.17"
+source = "git+https://github.com/nickel-org/rust-url.git#cc82fe74d77d0d97a6927f5c67c21b19bd550048"
+dependencies = [
+ "matches 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "wca-data"
 version = "0.0.1"
 dependencies = [
- "csv 0.7.1 (git+git://github.com/BurntSushi/rust-csv)",
+ "csv 0.12.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,14 @@ name = "wca-api-rust"
 version = "0.0.1"
 authors = ["Tim Habermaas"]
 
+[dependencies]
+rustc-serialize = "0.2"
+
 [dependencies.nickel]
 git = "https://github.com/nickel-org/nickel.rs.git"
 
 [dependencies.wca-data]
 path = "src/data"
+
+[dependencies.http]
+git = "https://github.com/nickel-org/rust-http.git"

--- a/src/data/Cargo.toml
+++ b/src/data/Cargo.toml
@@ -4,5 +4,6 @@ name = "wca-data"
 version = "0.0.1"
 authors = ["Tim Habermaas"]
 
-[dependencies.csv]
-git = "git://github.com/BurntSushi/rust-csv"
+[dependencies]
+rustc-serialize = "0.2"
+csv = "0.12"

--- a/src/data/src/lib.rs
+++ b/src/data/src/lib.rs
@@ -14,13 +14,14 @@ pub mod wca_data {
     pub type WcaId = String;
     pub type PuzzleId = String;
 
-    #[derive(PartialEq, Clone)]
+    #[derive(PartialEq, Clone, Copy)]
     pub enum Gender {
         Male,
         Female,
         Unknown,
     }
 
+    #[derive(Copy)]
     pub enum ResultType {
         Single,
         Average,
@@ -44,7 +45,7 @@ pub mod wca_data {
     #[derive(RustcDecodable)]
     struct Person {
         id: WcaId,
-        subid: int,
+        subid: i32,
         name: String,
         country: String,
         gender: Gender,
@@ -55,17 +56,17 @@ pub mod wca_data {
         pub name: String,
         pub country: String,
         pub gender: Gender,
-        pub competition_count: uint,
+        pub competition_count: u32,
     }
 
     #[derive(RustcDecodable)]
     struct Rank {
         person_id: WcaId,
         event_id: String,
-        best: uint,
-        world_rank: uint,
-        continent_rank: uint,
-        country_rank: uint,
+        best: u32,
+        world_rank: u32,
+        continent_rank: u32,
+        country_rank: u32,
     }
 
     pub struct Ranking {
@@ -74,9 +75,9 @@ pub mod wca_data {
     }
 
     // TODO add puzzle enum
-    #[derive(RustcDecodable, RustcEncodable, Clone)]
+    #[derive(RustcDecodable, RustcEncodable, Clone, Copy)]
     pub struct CompResult {
-        pub time: uint,
+        pub time: u32,
     }
 
     #[derive(RustcDecodable, RustcEncodable, Clone)]
@@ -125,13 +126,13 @@ pub mod wca_data {
         fn update_competition_count_cache(&mut self) {
             for (id, competitor) in self.persons.iter_mut() {
                 match self.competitions.get(id) {
-                    Some(set) => { competitor.competition_count = set.len(); },
+                    Some(set) => { competitor.competition_count = set.len() as u32; },
                     None      => { },
                 }
             }
         }
 
-        fn add_single_record(&mut self, id: String, puzzle: String, time: uint) {
+        fn add_single_record(&mut self, id: String, puzzle: String, time: u32) {
             if self.records.contains_key(&id.clone()) {
             } else {
                 self.records.insert(id.clone(), HashMap::new());
@@ -140,7 +141,7 @@ pub mod wca_data {
             map.insert(puzzle, Record{single: CompResult{time: time}, average: None});
         }
 
-        fn add_single_ranking(&mut self, puzzle_id: String, best: uint, competitor_id: String) {
+        fn add_single_ranking(&mut self, puzzle_id: String, best: u32, competitor_id: String) {
             if self.single_rankings.contains_key(&puzzle_id) {
             } else {
                 self.single_rankings.insert(puzzle_id.clone(), vec![]);
@@ -149,7 +150,7 @@ pub mod wca_data {
             vec.push(Ranking { result: CompResult {time: best}, competitor_id: competitor_id.clone()});
         }
 
-        fn add_average_ranking(&mut self, puzzle_id: String, best: uint, competitor_id: String) {
+        fn add_average_ranking(&mut self, puzzle_id: String, best: u32, competitor_id: String) {
             if self.average_rankings.contains_key(&puzzle_id) {
             } else {
                 self.average_rankings.insert(puzzle_id.clone(), vec![]);
@@ -158,13 +159,13 @@ pub mod wca_data {
             vec.push(Ranking { result: CompResult {time: best}, competitor_id: competitor_id.clone()});
         }
 
-        fn add_average_record(&mut self, id: String, puzzle: String, time: uint) {
+        fn add_average_record(&mut self, id: String, puzzle: String, time: u32) {
             // This assumes that
             // a) Adding single records have been executed first.
             // b) For every average record exists one single record.
 
             // FIXME this exists to hack around borrow checker
-            let mut record = Record { single: CompResult {time: 2u}, average: None };
+            let mut record;
 
             {
                 let records = self.records.get(&id).unwrap();
@@ -174,7 +175,7 @@ pub mod wca_data {
             self.records.get_mut(&id).unwrap().insert(puzzle, Record { single: record.clone().single, average: Some(CompResult{time: time}) });
         }
 
-        pub fn number_of_comps(&self, id: &String) -> Option<uint> {
+        pub fn number_of_comps(&self, id: &String) -> Option<usize> {
             self.competitions.get(id).map(|set| set.len())
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,15 @@
 extern crate nickel;
 extern crate "wca-data" as w;
-extern crate serialize;
 extern crate http;
+extern crate "rustc-serialize" as rustc_serialize;
 
 use std::sync::Arc;
 
-use std::io::net::ip::Ipv4Addr;
-use nickel::{ Halt, Nickel, Request, QueryString, Response, HttpRouter, RequestHandler, MiddlewareResult };
+use std::old_io::net::ip::Ipv4Addr;
+use nickel::{ Halt, Nickel, Request, QueryString, Response, HttpRouter, Middleware, MiddlewareResult };
 use w::wca_data;
-use std::collections::TreeMap;
-use serialize::json::{mod, Json, ToJson};
+use std::collections::BTreeMap;
+use rustc_serialize::json::{mod, Json, ToJson};
 use http::status;
 use http::headers::content_type::MediaType;
 
@@ -44,7 +44,7 @@ struct Competitor {
     competition_count: uint,
 }
 
-#[deriving(Encodable, PartialEq)]
+#[derive(RustcEncodable, PartialEq)]
 struct CompetitorPartOfCollection<'a> {
     id: &'a str,
     name: &'a str,
@@ -53,7 +53,7 @@ struct CompetitorPartOfCollection<'a> {
     competition_count: uint,
 }
 
-#[deriving(Encodable)]
+#[derive(RustcEncodable)]
 struct Ranking<'a> {
     time: uint,
     competitor: CompetitorPartOfCollection<'a>,
@@ -61,7 +61,7 @@ struct Ranking<'a> {
 
 impl ToJson for Competitor {
     fn to_json(&self) -> Json {
-        let mut sub = TreeMap::new();
+        let mut sub = BTreeMap::new();
         sub.insert("id".to_string(), self.id.to_json());
         sub.insert("name".to_string(), self.name.to_json());
         sub.insert("competition_count".to_string(), self.competition_count.to_json());
@@ -72,7 +72,7 @@ impl ToJson for Competitor {
         };
         sub.insert("gender".to_string(), gender.to_json());
 
-        let mut d = TreeMap::new();
+        let mut d = BTreeMap::new();
         d.insert("competitor".to_string(), Json::Object(sub));
         Json::Object(d)
     }
@@ -80,19 +80,19 @@ impl ToJson for Competitor {
 
 
 
-impl RequestHandler for CompetitorHandler {
-    fn handle(&self, req: &Request, res: &mut Response) -> MiddlewareResult {
+impl Middleware for CompetitorHandler {
+    fn invoke(&self, req: &mut Request, res: &mut Response) -> MiddlewareResult {
         let id = req.param("id");
         let result = self.data.find_competitor(&id.to_string());
 
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
 
         match result {
             Some(c) => {
-                let c = Competitor { id: c.id.clone(), name: c.name.clone(), gender: c.gender, competition_count: c.competition_count };
+                let c = Competitor { id: c.id.clone(), name: c.name.clone(), gender: c.gender.clone(), competition_count: c.competition_count };
                 let data = c.to_json().to_string();
                 res.send(data);
             },
@@ -106,12 +106,12 @@ impl RequestHandler for CompetitorHandler {
     }
 }
 
-impl RequestHandler for RecordsHandler {
-    fn handle(&self, req: &Request, res: &mut Response) -> MiddlewareResult {
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
+impl Middleware for RecordsHandler {
+    fn invoke(&self, req: &mut Request, res: &mut Response) -> MiddlewareResult {
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
 
         let puzzle = req.param("puzzle_id");
         let type_   = req.param("type");
@@ -136,7 +136,7 @@ impl RequestHandler for RecordsHandler {
                     }
                 }
                 ).collect();
-                res.send(format!("{}", json::encode(&rankings)));
+                res.send(json::encode(&rankings).unwrap());
             },
             None => {
                 res.status_code(status::NotFound);
@@ -156,35 +156,35 @@ fn gender_to_str(gender: &wca_data::Gender) -> &str {
     }
 }
 
-impl RequestHandler for CompetitorSearchHandler {
-    fn handle(&self, req: &Request, res: &mut Response) -> MiddlewareResult {
+impl Middleware for CompetitorSearchHandler {
+    fn invoke(&self, req: &mut Request, res: &mut Response) -> MiddlewareResult {
         let q = req.query("q", "default");
         let m = q.get(0).unwrap();
         let competitors = self.data.find_competitors(m);
         let competitors: Vec<CompetitorPartOfCollection> = competitors.iter().map(|c| CompetitorPartOfCollection { id: c.id.as_slice(), name: c.name.as_slice(), gender: gender_to_str(&c.gender), country: c.country.as_slice(), competition_count: c.competition_count }).collect();
-        let mut wrapped_competitors: TreeMap<String, &Vec<CompetitorPartOfCollection>> = TreeMap::new();
+        let mut wrapped_competitors: BTreeMap<String, &Vec<CompetitorPartOfCollection>> = BTreeMap::new();
         wrapped_competitors.insert("competitors".to_string(), &competitors);
 
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
-        res.send(format!("{}", json::encode(&wrapped_competitors)));
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
+        res.send(json::encode(&wrapped_competitors).unwrap());
         Ok(Halt)
     }
 }
 
-impl RequestHandler for CompetitorRecordsHandler {
-    fn handle(&self, req: &Request, res: &mut Response) -> MiddlewareResult {
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
+impl Middleware for CompetitorRecordsHandler {
+    fn invoke(&self, req: &mut Request, res: &mut Response) -> MiddlewareResult {
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
 
         let id = req.param("id");
         match self.data.find_records(&id.to_string()) {
             Some(r) => {
-                res.send(json::encode(r));
+                res.send(json::encode(r).unwrap());
             },
             None => {
                 res.status_code(status::NotFound);
@@ -196,30 +196,34 @@ impl RequestHandler for CompetitorRecordsHandler {
     }
 }
 
-impl RequestHandler for EventsHandler {
-    fn handle(&self, _: &Request, res: &mut Response) -> MiddlewareResult {
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
-        res.send(json::encode(self.data.find_events()));
+impl Middleware for EventsHandler {
+    fn invoke(&self, _: &mut Request, res: &mut Response) -> MiddlewareResult {
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
+        res.send(json::encode(self.data.find_events()).unwrap());
 
         Ok(Halt)
     }
 }
 
-impl RequestHandler for SelectiveRecordsHandler {
-    fn handle(&self, req: &Request, res: &mut Response) -> MiddlewareResult {
-        res.origin.headers.content_type = Some(MediaType::new("application".into_string(),
-                                                              "json".into_string(),
-                                                              vec![("charset".into_string(),
-                                                              "utf8".into_string())]));
+impl Middleware for SelectiveRecordsHandler {
+    fn invoke(&self, req: &mut Request, res: &mut Response) -> MiddlewareResult {
+        res.origin.headers.content_type = Some(MediaType::new("application".to_string(),
+                                                              "json".to_string(),
+                                                              vec![("charset".to_string(),
+                                                              "utf8".to_string())]));
 
+        let mut puzzle_id = String::new();
+        {
+            let req2 = &req;
+            puzzle_id = req2.param("puzzle_id").to_string();
+        }
         let ids = req.query("ids", "");
-        let puzzle_id = req.param("puzzle_id");
-        let records = self.data.find_rankings_for(&puzzle_id.to_string(), ids);
+        let records = self.data.find_rankings_for(&puzzle_id.to_string(), ids.into_owned());
 
-        res.send(json::encode(&records));
+        res.send(json::encode(&records).unwrap());
 
         Ok(Halt)
     }
@@ -246,7 +250,6 @@ fn main() {
     router.get("/records/:puzzle_id", SelectiveRecordsHandler { data: w_arc.clone() });
     router.get("/events", EventsHandler { data: w_arc.clone() });
 
-    server.utilize(Nickel::query_string());
     server.utilize(router);
 
     server.listen(Ipv4Addr(0, 0, 0, 0), 6767);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,8 @@ use std::old_io::net::ip::Ipv4Addr;
 use nickel::{ Halt, Nickel, Request, QueryString, Response, HttpRouter, Middleware, MiddlewareResult };
 use w::wca_data;
 use std::collections::BTreeMap;
-use rustc_serialize::json::{mod, Json, ToJson};
+use rustc_serialize::json;
+use rustc_serialize::json::{Json, ToJson};
 use http::status;
 use http::headers::content_type::MediaType;
 
@@ -41,7 +42,7 @@ struct Competitor {
     id: String,
     name: String,
     gender: wca_data::Gender,
-    competition_count: uint,
+    competition_count: u32,
 }
 
 #[derive(RustcEncodable, PartialEq)]
@@ -50,12 +51,12 @@ struct CompetitorPartOfCollection<'a> {
     name: &'a str,
     gender: &'a str,
     country: &'a str,
-    competition_count: uint,
+    competition_count: u32,
 }
 
 #[derive(RustcEncodable)]
 struct Ranking<'a> {
-    time: uint,
+    time: u32,
     competitor: CompetitorPartOfCollection<'a>,
 }
 
@@ -215,7 +216,7 @@ impl Middleware for SelectiveRecordsHandler {
                                                               vec![("charset".to_string(),
                                                               "utf8".to_string())]));
 
-        let mut puzzle_id = String::new();
+        let mut puzzle_id;
         {
             let req2 = &req;
             puzzle_id = req2.param("puzzle_id").to_string();

--- a/tests/record_test.rs
+++ b/tests/record_test.rs
@@ -14,7 +14,7 @@ fn single_records() {
     let three_by_three = record.get(&"333".to_string()).unwrap();
     let four_by_four   = record.get(&"444".to_string()).unwrap();
 
-    assert_eq!(three_by_three.single.time, 708u);
+    assert_eq!(three_by_three.single.time, 708);
     assert_eq!(four_by_four.single.time, 2999);
 }
 
@@ -26,7 +26,7 @@ fn average_records() {
     let three_by_three = record.get(&"333".to_string()).unwrap();
     let blindfolded_44 = record.get(&"444bf".to_string()).unwrap();
 
-    assert_eq!(three_by_three.average.unwrap().time, 931u);
+    assert_eq!(three_by_three.clone().average.unwrap().time, 931);
     assert_eq!(blindfolded_44.average.is_none(), true);
 }
 
@@ -35,7 +35,7 @@ fn single_rankings() {
     let w = setup_data();
     let ranks = w.find_rankings(&"333".to_string(), wca_data::ResultType::Single).unwrap();
     assert_eq!(ranks.len(), 4);
-    assert_eq!(ranks.get(0).unwrap().result.time, 708u);
+    assert_eq!(ranks.get(0).unwrap().result.time, 708);
     assert_eq!(ranks.get(0).unwrap().competitor_id, "2005AKKE01".to_string());
     assert_eq!(ranks.get(1).unwrap().result.time, 871);
     assert_eq!(ranks.get(1).unwrap().competitor_id, "2003BRUC01".to_string());
@@ -54,9 +54,9 @@ fn average_rankings() {
     let w = setup_data();
     let ranks = w.find_rankings(&"333".to_string(), wca_data::ResultType::Average).unwrap();
     assert_eq!(ranks.len(), 2);
-    assert_eq!(ranks.get(0).unwrap().result.time, 931u);
+    assert_eq!(ranks.get(0).unwrap().result.time, 931);
     assert_eq!(ranks.get(0).unwrap().competitor_id, "2005AKKE01".to_string());
-    assert_eq!(ranks.get(1).unwrap().result.time, 1262u);
+    assert_eq!(ranks.get(1).unwrap().result.time, 1262);
     assert_eq!(ranks.get(1).unwrap().competitor_id, "2003BRUC01".to_string());
 }
 


### PR DESCRIPTION
* [x] Remove warnings about `uint` being deprecated.